### PR TITLE
Add readme instructions on running examples with cargo ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ smol = "1" # or any other runtime/executor
 async-tftp = "0.3"
 ```
 
+## Running examples with cargo
+There are some examples included with this crate.
+You can run them from a source checkout with cargo:
+```bash
+$ cargo run --example tftpd-dir
+TFTP directory: ...
+Listening on: 0.0.0.0:6969
+^C
+
+$ cargo run --example tftpd-targz <archive-path>
+Listening on: 0.0.0.0:6969
+^C
+```
+
 # License
 
 [MIT][license]

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ async-tftp = "0.3"
 ```
 
 ## Running examples with cargo
+
 There are some examples included with this crate.
 You can run them from a source checkout with cargo:
+
 ```bash
 $ cargo run --example tftpd-dir
 TFTP directory: ...


### PR DESCRIPTION
This is intended to address [issue #9 - Provide binary](https://github.com/oblique/async-tftp-rs/issues/9).

It is possible to run the provide examples with cargo:

``` bash
$ cargo run --example tftpd-dir
TFTP directory: ...
Listening on: 0.0.0.0:6969
^C
$ cargo run --example tftpd-targz <archive-path>
Listening on: 0.0.0.0:6969
^C
```


