### PR TITLE
Send responses and errors from the bind address

### DIFF
--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -183,12 +183,14 @@ impl<H: Handler> TftpServerBuilder<H> {
             ignore_client_block_size: self.ignore_client_block_size,
         };
 
+        let local_ip = socket.as_ref().local_addr()?.ip();
         Ok(TftpServer {
             socket,
             handler: Arc::new(Mutex::new(self.handle)),
             reqs_in_progress: Arc::new(Mutex::new(HashSet::new())),
             ex: Executor::new(),
             config,
+            local_ip,
         })
     }
 }

--- a/src/server/read_req.rs
+++ b/src/server/read_req.rs
@@ -4,7 +4,7 @@ use futures_lite::{AsyncRead, AsyncReadExt};
 use log::trace;
 use std::cmp;
 use std::io;
-use std::net::{SocketAddr, UdpSocket};
+use std::net::{IpAddr, SocketAddr, UdpSocket};
 use std::slice;
 use std::time::Duration;
 
@@ -37,6 +37,7 @@ where
         peer: SocketAddr,
         req: &RwReq,
         config: ServerConfig,
+        local_ip: IpAddr,
     ) -> Result<ReadRequest<'r, R>> {
         let oack_opts = build_oack_opts(&config, req, file_size);
 
@@ -52,7 +53,7 @@ where
             .map(|t| Duration::from_secs(u64::from(t)))
             .unwrap_or(config.timeout);
 
-        let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        let addr = SocketAddr::new(local_ip, 0);
         let socket = Async::<UdpSocket>::bind(addr).map_err(Error::Bind)?;
 
         Ok(ReadRequest {

--- a/src/server/write_req.rs
+++ b/src/server/write_req.rs
@@ -4,7 +4,7 @@ use futures_lite::{AsyncWrite, AsyncWriteExt};
 use log::trace;
 use std::cmp;
 use std::io;
-use std::net::{SocketAddr, UdpSocket};
+use std::net::{IpAddr, SocketAddr, UdpSocket};
 use std::time::Duration;
 
 use crate::error::{Error, Result};
@@ -40,6 +40,7 @@ where
         peer: SocketAddr,
         req: &RwReq,
         config: ServerConfig,
+        local_ip: IpAddr,
     ) -> Result<WriteRequest<'w, W>> {
         let oack_opts = build_oack_opts(&config, req);
 
@@ -55,7 +56,7 @@ where
             .map(|t| Duration::from_secs(u64::from(t)))
             .unwrap_or(config.timeout);
 
-        let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        let addr = SocketAddr::new(local_ip, 0);
         let socket = Async::<UdpSocket>::bind(addr).map_err(Error::Bind)?;
 
         Ok(WriteRequest {


### PR DESCRIPTION
Use the bind address to send the responses and errors from, rather than "0.0.0.0:0". This automatically adds IPv6 support since trying to send a response to a IPv6 client from an IPv4 socket would result in a protocol mismatch error.