### PR TITLE
write_req: Close file after writing

### DIFF
--- a/src/server/write_req.rs
+++ b/src/server/write_req.rs
@@ -108,6 +108,9 @@ where
             }
         }
 
+        self.writer.flush().await?;
+        self.writer.close().await?;
+
         Ok(())
     }
 


### PR DESCRIPTION
When implementing advanced handlers, it is necessary to know when an upload is done, so further processing can start.

The ``AsyncWrite`` trait has 3 methods:
- ``poll_write()``
- ``poll_flush()``
- ``poll_close()``

Before this patch, ``poll_write()`` was called one or more times, so the writer didn't know when a transfer was complete. ``poll_flush()`` and ``poll_close()`` was never called.

This patch closes the writer upon completion, causing ``poll_close()`` to be called on the writer.